### PR TITLE
Making container image more functional

### DIFF
--- a/images/openemr/Dockerfile
+++ b/images/openemr/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8 as builder
 
 RUN dnf update -y
-RUN dnf install -y @php php-mysqlnd php-soap php-gd php-pecl-zip wget git npm
+RUN dnf install -y @php php-mysqlnd php-soap php-gd php-pecl-zip wget git npm && dnf clean all
 RUN wget https://getcomposer.org/installer -O composer-installer.php
 RUN wget https://raw.githubusercontent.com/openemr/openemr-devops/master/docker/openemr/5.0.3/php.ini https://raw.githubusercontent.com/openemr/openemr-devops/master/docker/openemr/5.0.3/openemr.conf
 RUN php composer-installer.php --filename=composer --install-dir=/usr/local/bin
@@ -22,14 +22,20 @@ RUN composer global require phing/phing \
     && rm -fr node_modules
 
 FROM registry.access.redhat.com/ubi8
-RUN dnf install -y @php php-mysqlnd php-soap php-gd httpd mod_ssl
+RUN dnf install -y @php php-mysqlnd php-soap php-gd httpd mod_ssl && dnf clean all
 COPY --from=builder /php.ini /etc/php7/php.ini
 COPY --from=builder /openemr /var/www/localhost/htdocs/openemr
-COPY --from=builder /openemr.conf /etc/httpd/conf.d/
+
+COPY openemr.conf /etc/httpd/conf.d/ssl.conf
+COPY ssl.conf /etc/httpd/conf.d/ssl.conf
 
 # left-over from upstream, do we really need this?
 ENV APACHE_LOG_DIR=/var/log/httpd
 
+RUN chmod 0777 /run/httpd
+RUN chmod 0770 /var/log/httpd
+
+RUN sed -i 's/^Listen 80/Listen 8080/' /etc/httpd/conf/httpd.conf
 CMD exec /usr/sbin/httpd -D FOREGROUND
 
-EXPOSE 80 443
+EXPOSE 8080 8443

--- a/images/openemr/Dockerfile
+++ b/images/openemr/Dockerfile
@@ -26,7 +26,7 @@ RUN dnf install -y @php php-mysqlnd php-soap php-gd httpd mod_ssl && dnf clean a
 COPY --from=builder /php.ini /etc/php7/php.ini
 COPY --from=builder /openemr /var/www/localhost/htdocs/openemr
 
-COPY openemr.conf /etc/httpd/conf.d/ssl.conf
+COPY openemr.conf /etc/httpd/conf.d/openemr.conf
 COPY ssl.conf /etc/httpd/conf.d/ssl.conf
 
 # left-over from upstream, do we really need this?

--- a/images/openemr/README.md
+++ b/images/openemr/README.md
@@ -3,6 +3,6 @@ This is rewrite of original [upstream image](https://github.com/openemr/openemr-
 Notable differences:
  - Based on UBI
  - Using multi-staged build (and hence results in smaller image size)
- - Without reddis (needs to be spun-up separately)
+ - Without redis (needs to be spun-up separately)
  - without cron
  - without bundled ssl certificate

--- a/images/openemr/openemr.conf
+++ b/images/openemr/openemr.conf
@@ -37,7 +37,7 @@ CustomLog ${APACHE_LOG_DIR}/access.log combined
 ### with #'s below to enable HTTPS  ###
 ### redirection & require HTTPS only ##
 #######################################
-<VirtualHost *:80>
+<VirtualHost *:8080>
     #RewriteEngine On
     #RewriteCond %{HTTPS} off
     #RewriteRule (.*) https://%{HTTP_HOST}/$1 [R,L]

--- a/images/openemr/openemr.conf
+++ b/images/openemr/openemr.conf
@@ -1,0 +1,55 @@
+LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule allowmethods_module modules/mod_allowmethods.so
+## Security Options
+# Strong HTTP Protocol
+HTTPProtocolOptions Strict
+Protocols http/1.1
+# Don't Reveal Server
+ServerSignature off
+ServerTokens Prod
+Header unset Server
+# No ETag
+FileETag None
+Header unset ETag
+# Set HSTS and X-XSS protection
+Header set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+Header set X-XSS-Protection "1; mode=block"
+# Narrow document root
+DocumentRoot /var/www/localhost/htdocs/openemr
+ErrorLog ${APACHE_LOG_DIR}/error.log
+CustomLog ${APACHE_LOG_DIR}/access.log combined
+<Directory /var/www/localhost/htdocs/openemr>
+    # Only allow these HTTP Methods
+    AllowMethods GET POST PUT DELETE HEAD OPTIONS
+    # No indexes anywhere
+    Options -Indexes
+    AllowOverride FileInfo
+    Require all granted
+</Directory>
+<Directory "/var/www/localhost/htdocs/openemr/sites">
+    AllowOverride None
+</Directory>
+<Directory "/var/www/localhost/htdocs/openemr/sites/*/documents">
+    Require all denied
+</Directory>
+#######################################
+### Uncomment the following 3 lines ###
+### with #'s below to enable HTTPS  ###
+### redirection & require HTTPS only ##
+#######################################
+<VirtualHost *:80>
+    #RewriteEngine On
+    #RewriteCond %{HTTPS} off
+    #RewriteRule (.*) https://%{HTTP_HOST}/$1 [R,L]
+</VirtualHost>
+<VirtualHost _default_:8443>
+    #   SSL Engine Switch:
+    #   Enable/Disable SSL for this virtual host.
+    SSLEngine on
+    SSLHonorCipherOrder on
+    #   Used following tool to produce below ciphers: https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=apache-2.4.39&openssl=1.1.1&hsts=yes&profile=modern
+    SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
+    SSLProtocol -ALL +TLSv1.2
+    SSLCertificateFile    /etc/ssl/certs/tls.crt
+    SSLCertificateKeyFile /etc/ssl/certs/tls.key
+</VirtualHost>

--- a/images/openemr/ssl.conf
+++ b/images/openemr/ssl.conf
@@ -1,0 +1,46 @@
+LoadModule ssl_module modules/mod_ssl.so
+LoadModule socache_shmcb_module modules/mod_socache_shmcb.so
+
+SSLRandomSeed startup file:/dev/urandom 512
+SSLRandomSeed connect builtin
+
+Listen 8443
+
+SSLCipherSuite HIGH:MEDIUM:!MD5:!RC4:!3DES:!ADH
+SSLProxyCipherSuite HIGH:MEDIUM:!MD5:!RC4:!3DES:!ADH
+
+SSLHonorCipherOrder on
+
+SSLProtocol all -SSLv3
+SSLProxyProtocol all -SSLv3
+
+SSLPassPhraseDialog  builtin
+
+SSLSessionCache        "shmcb:/var/cache/mod_ssl/scache(512000)"
+SSLSessionCacheTimeout  300
+
+<VirtualHost _default_:8443>
+    DocumentRoot "/var/www/localhost/htdocs"
+    ServerName www.example.com:8443
+    ServerAdmin you@example.com
+    ErrorLog logs/ssl_error.log
+    TransferLog logs/ssl_access.log
+
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/tls.crt
+    SSLCertificateKeyFile /etc/ssl/certs/tls.key
+
+    <FilesMatch "\.(cgi|shtml|phtml|php)$">
+        SSLOptions +StdEnvVars
+    </FilesMatch>
+    <Directory "/var/www/localhost/cgi-bin">
+        SSLOptions +StdEnvVars
+    </Directory>
+
+    BrowserMatch "MSIE [2-5]" \
+            nokeepalive ssl-unclean-shutdown \
+            downgrade-1.0 force-response-1.0
+
+    CustomLog logs/ssl_request.log \
+            "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+</VirtualHost>


### PR DESCRIPTION
@isimluk Here's some work on the Dockerfile so it will run in OpenShift (4). ~~It runs now but still only seeing the default Apache HTTPD webpage.~~ Now just getting HTTP 503's.

If you want to run a build version of this:

1. You'll need some certs:
```
# oc create secret generic certs --from-file=tls.key=webserver.key.pem --from-file=tls.crt=webserver.cert.pem
```
2. Use new-app with an image I built for testing:
```
# oc new-app quay.io/bostrt/openemr-test
```
3. Mount in the certs:
```
# oc set volumes dc/openemr-test --add -t secret --secret-name=certs -m /etc/ssl/certs
```

This should deploy? :thinking: 