### PR TITLE
Docker Swarm mode needs to be disabled in OpenShift/K8s env

### DIFF
--- a/artifacts/openemr/openemr-deployment.yaml
+++ b/artifacts/openemr/openemr-deployment.yaml
@@ -58,8 +58,8 @@ spec:
         - name: REDIS_SERVER
           value: "redis"
         - name: SWARM_MODE
-          value: "yes"
-          image: "quay.io/openemr/openemr:latest"
+          value: "no"
+        image: "quay.io/openemr/openemr:latest"
         imagePullPolicy: ""
         name: openemr
         ports:


### PR DESCRIPTION
`SWARM_MODE` will need to be disabled for multiple reasons since it isn't supported inside OpenShift.