### PR TITLE
Ports have moved to 8080/8443 to prevent need for root.

### DIFF
--- a/artifacts/openemr/openemr-deployment.yaml
+++ b/artifacts/openemr/openemr-deployment.yaml
@@ -1,12 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.cmd: kompose convert
-    kompose.version: 1.21.0 ()
-  creationTimestamp: null
-  labels:
-    io.kompose.service: openemr
   name: openemr
 spec:
   replicas: 5
@@ -17,10 +11,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      annotations:
-        kompose.cmd: kompose convert
-        kompose.version: 1.21.0 ()
-      creationTimestamp: null
       labels:
         io.kompose.service: openemr
     spec:
@@ -59,12 +49,12 @@ spec:
           value: "redis"
         - name: SWARM_MODE
           value: "yes"
-          image: "quay.io/openemr/openemr:latest"
+        image: "quay.io/openemr/openemr:latest"
         imagePullPolicy: ""
         name: openemr
         ports:
-        - containerPort: 80
-        - containerPort: 443
+        - containerPort: 8080
+        - containerPort: 8443
         resources: {}
         volumeMounts:
         - mountPath: /var/www/localhost/htdocs/openemr/sites
@@ -87,5 +77,3 @@ spec:
         secret:
           defaultMode: 420
           secretName: openemr-certs
-status: {}
-

--- a/artifacts/openemr/openemr-service.yaml
+++ b/artifacts/openemr/openemr-service.yaml
@@ -2,22 +2,17 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    kompose.cmd: kompose convert
-    kompose.version: 1.7.0 (HEAD)
     service.alpha.openshift.io/serving-cert-secret-name: openemr-certs
-  creationTimestamp: null
   labels:
     io.kompose.service: openemr
   name: openemr
 spec:
   ports:
-  - name: "80"
-    port: 80
-    targetPort: 80
-  - name: "443"
-    port: 443
-    targetPort: 443
+  - name: "8080"
+    port: 8080
+    targetPort: 8080
+  - name: "8443"
+    port: 8443
+    targetPort: 8443
   selector:
     io.kompose.service: openemr
-status:
-  loadBalancer: {}


### PR DESCRIPTION
- Update to OpenEMR Deployment and Service to use ports 8443/8080. 
- Minor typo fix and removing unneeded information from the initial kompose import.