### PR TITLE
Enable app initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ oc apply -f artifacts/phpmyadmin/
 oc apply -f artifacts/openemr/
 ```
 
+For the first boot of the application certain initialization procedures (populating database and disk volumes) are required.
+```
+oc apply -f artifacts/openemr-firstboot
+```
+
 ### Deployment in vanilla kubernetes
 
 ```

--- a/artifacts/openemr-firstboot/firstboot-job.yaml
+++ b/artifacts/openemr-firstboot/firstboot-job.yaml
@@ -1,0 +1,65 @@
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: openemr-firstboot
+  labels:
+    job-name: openemr-firstboot
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 6
+  template:
+    spec:
+      containers:
+        - name: openemr-firstboot
+          image: 'quay.io/slukasik/openemr-test:app-initialization'
+          imagePullPolicy: Always
+          command:
+            - bash
+            - '-c'
+            - cd /var/www/localhost/htdocs/openemr/; ./first_start.sh
+          env:
+          - name: MYSQL_HOST
+            valueFrom:
+              secretKeyRef:
+                name: mysql
+                key: host
+          - name: MYSQL_DATABASE
+            valueFrom:
+              secretKeyRef:
+                name: mysql
+                key: name
+          - name: MYSQL_USER
+            valueFrom:
+              secretKeyRef:
+                name: mysql
+                key: username
+          - name: MYSQL_PASS
+            valueFrom:
+              secretKeyRef:
+                name: mysql
+                key: password
+          - name: MYSQL_ROOT_PASS
+            valueFrom:
+              secretKeyRef:
+                name: mysql
+                key: root_password
+          - name: OE_PASS
+            value: "pass"
+          - name: OE_USER
+            value: "admin"
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /var/www/localhost/htdocs/openemr/sites/
+            name: websitevolume
+      volumes:
+      - name: websitevolume
+        persistentVolumeClaim:
+          claimName: websitevolume
+      restartPolicy: Never
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler

--- a/artifacts/openemr/openemr-deployment.yaml
+++ b/artifacts/openemr/openemr-deployment.yaml
@@ -45,12 +45,8 @@ spec:
           value: "pass"
         - name: OE_USER
           value: "admin"
-        - name: REDIS_SERVER
-          value: "redis"
-        - name: SWARM_MODE
-          value: "no"
-        image: "quay.io/openemr/openemr:latest"
-        imagePullPolicy: ""
+        image: "quay.io/slukasik/openemr-test:app-initialization"
+        imagePullPolicy: Always
         name: openemr
         ports:
         - containerPort: 8080

--- a/images/openemr/Dockerfile
+++ b/images/openemr/Dockerfile
@@ -4,8 +4,7 @@ RUN dnf update -y
 RUN dnf install -y @php php-mysqlnd php-soap php-gd php-pecl-zip php-ldap wget git npm
 RUN wget https://getcomposer.org/installer -O composer-installer.php
 RUN wget https://raw.githubusercontent.com/openemr/openemr-devops/master/docker/openemr/5.0.2/php.ini
-RUN wget https://raw.githubusercontent.com/openemr/openemr-devops/master/docker/openemr/5.0.2/autoconfig.sh
-RUN wget https://raw.githubusercontent.com/openemr/openemr-devops/master/docker/openemr/5.0.2/auto_configure.php
+RUN wget https://raw.githubusercontent.com/openemr/openemr-devops/master/docker/openemr/5.0.2/autoconfig.sh https://raw.githubusercontent.com/openemr/openemr-devops/master/docker/openemr/5.0.3/auto_configure.php
 RUN php composer-installer.php --filename=composer --install-dir=/usr/local/bin
 
 
@@ -23,6 +22,7 @@ RUN composer global require phing/phing \
     && composer clearcache \
     && npm cache clear --force \
     && rm -fr node_modules
+RUN mv sites sites-seed
 
 FROM registry.access.redhat.com/ubi8
 RUN dnf install -y @php php php-mysqlnd php-soap php-gd httpd mod_ssl openssl && dnf clean all
@@ -31,7 +31,7 @@ COPY --from=builder /openemr /var/www/localhost/htdocs/openemr
 
 COPY openemr.conf /etc/httpd/conf.d/openemr.conf
 COPY ssl.conf /etc/httpd/conf.d/ssl.conf
-COPY run_openemr.sh /var/www/localhost/htdocs/openemr/
+COPY first_start.sh /var/www/localhost/htdocs/openemr/
 COPY --from=builder autoconfig.sh auto_configure.php /var/www/localhost/htdocs/openemr/
 RUN echo "LoadModule mpm_prefork_module modules/mod_mpm_prefork.so" > /etc/httpd/conf.modules.d/00-mpm.conf
 
@@ -45,6 +45,6 @@ RUN chown -R apache /var/www/localhost/htdocs/openemr/
 RUN sed -i 's/^Listen 80/Listen 8080/' /etc/httpd/conf/httpd.conf
 
 WORKDIR /var/www/localhost/htdocs/openemr/
-CMD [ "./run_openemr.sh" ]
+CMD exec /usr/sbin/httpd -D FOREGROUND
 
 EXPOSE 8080 8443

--- a/images/openemr/Dockerfile
+++ b/images/openemr/Dockerfile
@@ -9,7 +9,7 @@ RUN wget https://raw.githubusercontent.com/openemr/openemr-devops/master/docker/
 RUN php composer-installer.php --filename=composer --install-dir=/usr/local/bin
 
 
-RUN git clone https://github.com/openemr/openemr.git --branch rel-502 --depth 1
+RUN git clone https://github.com/openemr/openemr.git --depth 1
 
 WORKDIR openemr
 RUN composer install --no-dev

--- a/images/openemr/first_start.sh
+++ b/images/openemr/first_start.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -x -e -o pipefail
+
+
+auto_setup() {
+    CONFIGURATION="server=${MYSQL_HOST} rootpass=${MYSQL_ROOT_PASS} loginhost=%"
+    if [ "$MYSQL_ROOT_USER" != "" ]; then
+        CONFIGURATION="${CONFIGURATION} root=${MYSQL_ROOT_USER}"
+    fi
+    if [ "$MYSQL_USER" != "" ]; then
+        CONFIGURATION="${CONFIGURATION} login=${MYSQL_USER}"
+        CUSTOM_USER="$MYSQL_USER"
+    else
+        CUSTOM_USER="openemr"
+    fi
+    if [ "$MYSQL_PASS" != "" ]; then
+        CONFIGURATION="${CONFIGURATION} pass=${MYSQL_PASS}"
+        CUSTOM_PASSWORD="$MYSQL_PASS"
+    else
+        CUSTOM_PASSWORD="openemr"
+    fi
+    if [ "$MYSQL_DATABASE" != "" ]; then
+        CONFIGURATION="${CONFIGURATION} dbname=${MYSQL_DATABASE}"
+        CUSTOM_DATABASE="$MYSQL_DATABASE"
+    else
+        CUSTOM_DATABASE="openemr"
+    fi
+    if [ "$OE_USER" != "" ]; then
+        CONFIGURATION="${CONFIGURATION} iuser=${OE_USER}"
+    fi
+    if [ "$OE_PASS" != "" ]; then
+        CONFIGURATION="${CONFIGURATION} iuserpass=${OE_PASS}"
+    fi
+
+    php auto_configure.php -f ${CONFIGURATION} || return 1
+
+    echo "OpenEMR configured."
+    CONFIG=$(php -r "require_once('/var/www/localhost/htdocs/openemr/sites/default/sqlconf.php'); echo \$config;")
+    if [ "$CONFIG" == "0" ]; then
+        echo "Error in auto-config. Configuration failed."
+        exit 2
+    fi
+
+    #Turn on API from docker
+    if [ "$ACTIVATE_API" == "yes" ]; then
+        mysql -u "$CUSTOM_USER"  --password="$CUSTOM_PASSWORD" -h "$MYSQL_HOST" -e "UPDATE globals SET gl_value = 1 WHERE gl_name = \"rest_api\"" "$CUSTOM_DATABASE"
+    fi
+}
+
+
+
+mv /var/www/localhost/htdocs/openemr/sites-seed/* /var/www/localhost/htdocs/openemr/sites
+
+echo "Running quick setup!"
+
+while ! auto_setup; do
+    echo "Couldn't set up. Any of these reasons could be what's wrong:"
+    echo " - You didn't spin up a MySQL container or connect your OpenEMR container to a mysql instance"
+    echo " - MySQL is still starting up and wasn't ready for connection yet"
+    echo " - The Mysql credentials were incorrect"
+    sleep 1;
+done
+echo "Setup Complete!"


### PR DESCRIPTION
It seems that boostrap is still not working properly with our ubi based container.

At initial bootstrap of the application we want to conclude some initial set-up tasks (i.e. database migration). In the docker swarm mode it was done by selecting leader container and leader container running the initialization. OpenShift way to achieve this is to have cron job (at openshift level) that will schedule extra pod, just for the initialization. For that case we will re-use openemr container and hence we will store the first boot init script at that container.