### PR TITLE
WIP - Image Build Arguments and Docker Compose Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ OpenEMR configured.
 Setup Complete!
 ```
 
-The Docker Compose configuration provides an easy way to work alternate OpenEMR forks and releases. To rebuild the application locally, simply update the `image` and `build` configurations.
+The Docker Compose configuration provides an easy way to work with alternate OpenEMR forks and releases. To rebuild the application locally, simply update the `image` and `build` configurations.
 
 ```
 image: <your repository name>/openemr:<your tag>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Deployment
 
-### Preequisites
+### Prerequisites
 
 In order to use OpenEMR, a MySQL database is required.
 For development purposes, you can install a MariaDB database in the cluster:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Deployment
 
-### Perequisites
+### Preequisites
 
 In order to use OpenEMR, a MySQL database is required.
 For development purposes, you can install a MariaDB database in the cluster:
@@ -49,4 +49,59 @@ oc apply -f artifacts/openemr-firstboot
 ```
 kubectl apply -f artifacts/phpmyadmin/
 kubectl apply -f artifacts/openemr/
+```
+
+### Image Build Arguments
+
+| Build Argument | Description | Default |
+| -------------- | ----------- | ------- |
+| OPENEMR_REPO_URL | The OpenEMR Git URL used to fetch source code | The OpenEMR's offical GitHubURL |
+| OPENEMR_BRANCH | The OpenEMR branch built in the container | master |
+| ENABLE_SSL | Indicates if the web server configuration includes SSL. Valid values are true or false | true | 
+
+### Docker Compose Support for Local Use
+```
+docker-compose up -d
+
+# review logs for database and openemr availability
+docker-compose logs -f 
+
+# run openemr setup process (a PHP Warning will appear)
+docker-compose exec openemr sh -c "cd /var/www/localhost/htdocs/openemr && ./first_start.sh"
+
+Running quick setup!
++ auto_setup
+.....
+PHP Warning:  mysqli_connect(): (HY000/1045): Access denied for user 'openemr'@'192.168.208.3' (using password: YES) in /var/www/localhost/htdocs/openemr/library/classes/Installer.class.php on line 69
+.....
++ echo 'OpenEMR configured.'
+OpenEMR configured.
+++ php -r 'require_once('\''/var/www/localhost/htdocs/openemr/sites/default/sqlconf.php'\''); echo $config;'
++ CONFIG=1
++ '[' 1 == 0 ']'
++ '[' '' == yes ']'
++ echo 'Setup Complete!'
+Setup Complete!
+```
+
+The Docker Compose configuration provides an easy way to work alternate OpenEMR forks and releases. To rebuild the application locally, simply update the `image` and `build` configurations.
+
+```
+image: <your repository name>/openemr:<your tag>
+build:
+  context: images/openemr
+  args:
+    OPENEMR_REPO_URL: <Valid Git URL>
+    OPENEMR_BRANCH: <Git branch or tag name>
+    ENABLE_SSL: <true | false>
+```
+
+Finally, if SSL support is enabled, add volume mounts to support the server cert and key
+
+```
+volumes:
+- logvolume01:/var/log
+- sitevolume:/var/www/localhost/htdocs/openemr/sites
+- <local path>/<local cert>:/etc/ssl/certs/tls.crt
+- <local path>/<local key>:/etc/ssl/certs/tls.key
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
         ENABLE_SSL: "false"
     ports:
     - 8080:8080
-    - 4443:443
+    - 8443:8443
     volumes:
     - logvolume01:/var/log
     - sitevolume:/var/www/localhost/htdocs/openemr/sites

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # MYSQL_HOST and MYSQL_ROOT_PASS are required for openemr
 # MYSQL_USER, MYSQL_PASS, OE_USER, MYSQL_PASS are optional for openemr and
 #   if not provided, then default to openemr, openemr, admin, and pass respectively.
-version: '3'
+version: '3.7'
 services:
   mysql:
     restart: always
@@ -14,10 +14,16 @@ services:
       MYSQL_ROOT_PASSWORD: root
   openemr:
     restart: always
-    image: openemr/openemr:5.0.3
+    image: quay.io/openemr/openemr:latest
+    build:
+      context: images/openemr
+      args:
+        OPENEMR_REPO_URL: https://github.com/openemr/openemr.git
+        OPENEMR_BRANCH: master
+        ENABLE_SSL: "false"
     ports:
-    - 80:80
-    - 443:443
+    - 8080:8080
+    - 4443:443
     volumes:
     - logvolume01:/var/log
     - sitevolume:/var/www/localhost/htdocs/openemr/sites

--- a/images/openemr/Dockerfile
+++ b/images/openemr/Dockerfile
@@ -1,5 +1,8 @@
 FROM registry.access.redhat.com/ubi8 as builder
 
+ARG OPENEMR_REPO_URL="https://github.com/openemr/openemr.git"
+ARG OPENEMR_BRANCH=master
+
 RUN dnf update -y
 RUN dnf install -y @php php-mysqlnd php-soap php-gd php-pecl-zip php-ldap wget git npm
 RUN wget https://getcomposer.org/installer -O composer-installer.php
@@ -7,8 +10,7 @@ RUN wget https://raw.githubusercontent.com/openemr/openemr-devops/master/docker/
 RUN wget https://raw.githubusercontent.com/openemr/openemr-devops/master/docker/openemr/5.0.2/autoconfig.sh https://raw.githubusercontent.com/openemr/openemr-devops/master/docker/openemr/5.0.3/auto_configure.php
 RUN php composer-installer.php --filename=composer --install-dir=/usr/local/bin
 
-
-RUN git clone https://github.com/openemr/openemr.git --depth 1
+RUN git clone --depth 1 --branch $OPENEMR_BRANCH $OPENEMR_REPO_URL
 
 WORKDIR openemr
 RUN composer install --no-dev
@@ -25,12 +27,17 @@ RUN composer global require phing/phing \
 RUN mv sites sites-seed
 
 FROM registry.access.redhat.com/ubi8
+
+ARG ENABLE_SSL=true
+
 RUN dnf install -y @php php php-mysqlnd php-soap php-gd httpd mod_ssl openssl && dnf clean all
 COPY --from=builder /php.ini /etc/php.ini
 COPY --from=builder /openemr /var/www/localhost/htdocs/openemr
 
 COPY openemr.conf /etc/httpd/conf.d/openemr.conf
 COPY ssl.conf /etc/httpd/conf.d/ssl.conf
+RUN if [ "$ENABLE_SSL" == "false" ]; then mv /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/ssl.disabled; fi
+
 COPY first_start.sh /var/www/localhost/htdocs/openemr/
 COPY --from=builder autoconfig.sh auto_configure.php /var/www/localhost/htdocs/openemr/
 RUN echo "LoadModule mpm_prefork_module modules/mod_mpm_prefork.so" > /etc/httpd/conf.modules.d/00-mpm.conf
@@ -41,8 +48,6 @@ ENV APACHE_LOG_DIR=/var/log/httpd
 RUN chmod 0777 /run/httpd
 RUN chmod 0770 /var/log/httpd
 RUN chown -R apache /var/www/localhost/htdocs/openemr/
-
-RUN sed -i 's/^Listen 80/Listen 8080/' /etc/httpd/conf/httpd.conf
 
 WORKDIR /var/www/localhost/htdocs/openemr/
 CMD exec /usr/sbin/httpd -D FOREGROUND

--- a/images/openemr/openemr.conf
+++ b/images/openemr/openemr.conf
@@ -1,5 +1,8 @@
 LoadModule rewrite_module modules/mod_rewrite.so
 LoadModule allowmethods_module modules/mod_allowmethods.so
+
+Listen 8080
+
 ## Security Options
 # Strong HTTP Protocol
 HTTPProtocolOptions Strict
@@ -41,15 +44,4 @@ CustomLog ${APACHE_LOG_DIR}/access.log combined
     #RewriteEngine On
     #RewriteCond %{HTTPS} off
     #RewriteRule (.*) https://%{HTTP_HOST}/$1 [R,L]
-</VirtualHost>
-<VirtualHost _default_:8443>
-    #   SSL Engine Switch:
-    #   Enable/Disable SSL for this virtual host.
-    SSLEngine on
-    SSLHonorCipherOrder on
-    #   Used following tool to produce below ciphers: https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=apache-2.4.39&openssl=1.1.1&hsts=yes&profile=modern
-    SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
-    SSLProtocol -ALL +TLSv1.2
-    SSLCertificateFile    /etc/ssl/certs/tls.crt
-    SSLCertificateKeyFile /etc/ssl/certs/tls.key
 </VirtualHost>


### PR DESCRIPTION
Hello!

This PR updates the project to support build arguments for the image build process and rounds out the "upstream" Docker Compose configuration in this project to support them. 

The build arguments provide a means to specify which OpenEMR repo and branch are built in the image, and the ability to opt out of SSLsupport. All build arguments have meaningful defaults which align with the current implementation.

These changes would be helpful to my team since we are still working with a Docker Compose configuration. If these changes are  contrary to the project's direction, they can happily live on in my fork. 

Thanks!